### PR TITLE
Remove some iframe height that isn't necessary

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -50,7 +50,7 @@ dialog::backdrop {
   -ms-transform: translate(-50%, -50%);
   transform: translate(-50%, -50%);
   margin: 0;
-  max-height: 90%;
+  max-height: 100%;
   overflow: scroll;
 }
 
@@ -78,8 +78,7 @@ dialog::backdrop {
 
 .dialog-content {
   padding: 1em;
-  max-width: 90%;
-  width: 70%;
+  max-width: 1280px;
   border-radius: 2px;
 }
 
@@ -139,7 +138,7 @@ dialog > div a {
 
 body {
   font: 125% / 1.5 "Montserrat", sans-serif;
-  padding: 2em 0;
+  padding: 0;
 }
 
 h1 {
@@ -201,7 +200,7 @@ a:active {
 
 .main {
   margin: 0 auto;
-  padding: 0 1em;
+  padding: 0;
 }
 
 footer {

--- a/styles.css
+++ b/styles.css
@@ -132,12 +132,30 @@ dialog > div a {
  * Base stuff
  * -------------------------------------------------------------------------- */
 
+/**
+ * The HTML wrapping tag takes some very general styles. Normalize some rendering.
+ */
+html {
+  font-size: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -ms-text-size-adjust: 100%;
+  -webkit-font-smoothing: antialiased;
+  -webkit-text-size-adjust: 100%;
+  height: 100%;
+  text-rendering: optimizeLegibility;
+}
+
 * {
   box-sizing: border-box;
 }
 
 body {
-  font: 125% / 1.5 "Montserrat", sans-serif;
+  font-family: "Montserrat", Verdana, Arial, sans-serif;
+  font-size: 16px;
+  font-weight: 400;
+  height: 100%;
+  line-height: 1.375;
+  margin: 0;
   padding: 0;
 }
 


### PR DESCRIPTION
With the spacing inside the iframe removed, the iframe's height on the coastal staging site should be set to around 980 by 475 (though it may need to be a smidge taller or shorter). These additional styles should at least maximize the iframe space being used.